### PR TITLE
Potential fix for code scanning alert no. 2: Unsafe jQuery plugin

### DIFF
--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -96,9 +96,13 @@
 
 			// Validate "target" to prevent unsafe input.
 			function isValidTarget(target) {
-				// Ensure target is a valid CSS selector or DOM element.
+				// Ensure target is a valid CSS selector or DOM element and sanitize input.
 				try {
-					return typeof target === 'string' && target.trim().length > 0 && $(target).length > 0;
+					return typeof target === 'string' &&
+						target.trim().length > 0 &&
+						!target.trim().startsWith('<') && // Reject strings starting with '<'.
+						!/[<>]/.test(target) && // Reject strings containing '<' or '>'.
+						$(target).length > 0;
 				} catch (e) {
 					return false;
 				}
@@ -106,7 +110,7 @@
 
 			// Expand "target" if it's not a jQuery object already and is valid.
 			if (typeof config.target != 'jQuery' && isValidTarget(config.target))
-				config.target = $(config.target);
+				config.target = $.find(config.target); // Use jQuery.find for safe handling.
 			else
 				config.target = $this; // Default to the current element if invalid.
 


### PR DESCRIPTION
Potential fix for [https://github.com/alexoxy/fenixindustriesdefense.github.io/security/code-scanning/2](https://github.com/alexoxy/fenixindustriesdefense.github.io/security/code-scanning/2)

To fix the issue, the `isValidTarget` function should be updated to explicitly sanitize the `target` input and ensure it cannot be interpreted as HTML. Additionally, the plugin should use safer methods to handle the `target` option, such as `jQuery.find`, which does not evaluate strings as HTML. This ensures that the `target` is always treated as a CSS selector or DOM element.

Changes to make:
1. Update the `isValidTarget` function to sanitize the `target` input by rejecting strings that start with `<` or contain potentially dangerous characters.
2. Use `jQuery.find` instead of `$(target)` to ensure the `target` is treated as a CSS selector.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
