### PR TITLE
Potential fix for code scanning alert no. 4: Unsafe jQuery plugin

### DIFF
--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -97,20 +97,29 @@
 			// Validate "target" to prevent unsafe input.
 			function isValidTarget(target) {
 				// Ensure target is a valid CSS selector or DOM element and sanitize input.
-				try {
+
 					return typeof target === 'string' &&
 						target.trim().length > 0 &&
 						!target.trim().startsWith('<') && // Reject strings starting with '<'.
 						!/[<>]/.test(target) && // Reject strings containing '<' or '>'.
+						/^[a-zA-Z0-9.#\[\]=:()_-]+$/.test(target.trim()) && // Allow only valid CSS selector characters.
 						$(target).length > 0;
-				} catch (e) {
-					return false;
-				}
+						!target.trim().startsWith('<') && // Reject strings starting with '<'.
+
+						!/[<>]/.test(target) && // Reject strings containing '<' or '>'.
+			}
+						$(target).length > 0;
+
+			if (typeof config.target !== 'object' && isValidTarget(config.target)) {
+				config.target = $.find(config.target); // Use jQuery.find for safe handling.
+			} else {
+			}
 			}
 
 			// Expand "target" if it's not a jQuery object already and is valid.
 			if (typeof config.target != 'jQuery' && isValidTarget(config.target))
-				config.target = $.find(config.target); // Use jQuery.find for safe handling.
+				config.target = $.find(config.target); // Use jQuery.find for safe handling.
+
 			else
 				config.target = $this; // Default to the current element if invalid.
 


### PR DESCRIPTION
Potential fix for [https://github.com/alexoxy/fenixindustriesdefense.github.io/security/code-scanning/4](https://github.com/alexoxy/fenixindustriesdefense.github.io/security/code-scanning/4)

To fix the issue, we need to ensure that `config.target` is always treated as a CSS selector and never interpreted as HTML. This can be achieved by using `jQuery.find` for safe handling and improving the validation logic in `isValidTarget`. Specifically, we should:
1. Enhance the `isValidTarget` function to reject any input that could potentially be unsafe or malformed.
2. Ensure that `config.target` is sanitized and validated before being passed to `$.find`.
3. Default to `$this` if the input is invalid or unsafe.

The changes will be made in the `$.fn.panel` function, specifically in the validation logic and the handling of `config.target`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
